### PR TITLE
Allow disabling of new action

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -134,6 +134,23 @@ defmodule Kaffy.ResourceAdmin do
   end
 
   @doc """
+  `default_actions/1` takes a schema and returns the default actions for the schema.
+
+  If `default_actions/1` is not defined, Kaffy will return `[:new, :edit, :delete]`.
+
+  Example:
+
+  ```elixir
+  def default_actions(_schema) do
+    [:new, :delete]
+  end
+  ```
+  """
+  def default_actions(resource) do
+    Utils.get_assigned_value_or_default(resource, :default_actions, [:new, :edit, :delete])
+  end
+
+  @doc """
   `authorized?/2` takes the schema and the current Plug.Conn struct and
   should return a boolean value.
 

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -203,21 +203,21 @@ defmodule KaffyWeb.ResourceController do
     my_resource = Kaffy.Utils.get_resource(conn, context, resource)
     resource_name = Kaffy.ResourceAdmin.singular_name(my_resource)
 
-    case can_proceed?(my_resource, conn) do
-      false ->
-        unauthorized_access(conn)
+    with {:permitted, true} <- {:permitted, can_proceed?(my_resource, conn)},
+         {:enabled, true} <- {:enabled, is_enabled?(my_resource, :new)} do
+      changeset = Kaffy.ResourceAdmin.create_changeset(my_resource, %{}) |> Map.put(:errors, [])
 
-      true ->
-        changeset = Kaffy.ResourceAdmin.create_changeset(my_resource, %{}) |> Map.put(:errors, [])
-
-        render(conn, "new.html",
-          layout: {KaffyWeb.LayoutView, "app.html"},
-          changeset: changeset,
-          context: context,
-          resource: resource,
-          resource_name: resource_name,
-          my_resource: my_resource
-        )
+      render(conn, "new.html",
+        layout: {KaffyWeb.LayoutView, "app.html"},
+        changeset: changeset,
+        context: context,
+        resource: resource,
+        resource_name: resource_name,
+        my_resource: my_resource
+      )
+    else
+      {:permitted, false} -> unauthorized_access(conn)
+      {:enabled, false} -> not_enabled(conn)
     end
   end
 
@@ -227,56 +227,56 @@ defmodule KaffyWeb.ResourceController do
     changes = Map.get(params, resource, %{})
     resource_name = Kaffy.ResourceAdmin.singular_name(my_resource)
 
-    case can_proceed?(my_resource, conn) do
-      false ->
-        unauthorized_access(conn)
+    with {:permitted, true} <- {:permitted, can_proceed?(my_resource, conn)},
+         {:enabled, true} <- {:enabled, is_enabled?(my_resource, :new)} do
+      case Kaffy.ResourceCallbacks.create_callbacks(conn, my_resource, changes) do
+        {:ok, entry} ->
+          case Map.get(params, "submit", "Save") do
+            "Save" ->
+              put_flash(conn, :success, "Created a new #{resource_name} successfully")
+              |> redirect(
+                to: Kaffy.Utils.router().kaffy_resource_path(conn, :index, context, resource)
+              )
 
-      true ->
-        case Kaffy.ResourceCallbacks.create_callbacks(conn, my_resource, changes) do
-          {:ok, entry} ->
-            case Map.get(params, "submit", "Save") do
-              "Save" ->
-                put_flash(conn, :success, "Created a new #{resource_name} successfully")
-                |> redirect(
-                  to: Kaffy.Utils.router().kaffy_resource_path(conn, :index, context, resource)
-                )
+            "Save and add another" ->
+              conn
+              |> put_flash(:success, "#{resource_name} saved successfully")
+              |> redirect(
+                to: Kaffy.Utils.router().kaffy_resource_path(conn, :new, context, resource)
+              )
 
-              "Save and add another" ->
-                conn
-                |> put_flash(:success, "#{resource_name} saved successfully")
-                |> redirect(
-                  to: Kaffy.Utils.router().kaffy_resource_path(conn, :new, context, resource)
-                )
+            "Save and continue editing" ->
+              put_flash(conn, :success, "Created a new #{resource_name} successfully")
+              |> redirect_to_resource(context, resource, entry)
+          end
 
-              "Save and continue editing" ->
-                put_flash(conn, :success, "Created a new #{resource_name} successfully")
-                |> redirect_to_resource(context, resource, entry)
-            end
+        {:error, %Ecto.Changeset{} = changeset} ->
+          render(conn, "new.html",
+            layout: {KaffyWeb.LayoutView, "app.html"},
+            changeset: changeset,
+            context: context,
+            resource: resource,
+            resource_name: resource_name,
+            my_resource: my_resource
+          )
 
-          {:error, %Ecto.Changeset{} = changeset} ->
-            render(conn, "new.html",
-              layout: {KaffyWeb.LayoutView, "app.html"},
-              changeset: changeset,
-              context: context,
-              resource: resource,
-              resource_name: resource_name,
-              my_resource: my_resource
-            )
+        {:error, {entry, error}} when is_binary(error) ->
+          changeset = Ecto.Changeset.change(entry)
 
-          {:error, {entry, error}} when is_binary(error) ->
-            changeset = Ecto.Changeset.change(entry)
-
-            conn
-            |> put_flash(:error, error)
-            |> render("new.html",
-              layout: {KaffyWeb.LayoutView, "app.html"},
-              changeset: changeset,
-              context: context,
-              resource: resource,
-              resource_name: resource_name,
-              my_resource: my_resource
-            )
-        end
+          conn
+          |> put_flash(:error, error)
+          |> render("new.html",
+            layout: {KaffyWeb.LayoutView, "app.html"},
+            changeset: changeset,
+            context: context,
+            resource: resource,
+            resource_name: resource_name,
+            my_resource: my_resource
+          )
+      end
+    else
+      {:permitted, false} -> unauthorized_access(conn)
+      {:enabled, false} -> not_enabled(conn)
     end
   end
 
@@ -374,9 +374,19 @@ defmodule KaffyWeb.ResourceController do
     Kaffy.ResourceAdmin.authorized?(resource, conn)
   end
 
+  defp is_enabled?(resource, action) do
+    action in Kaffy.ResourceAdmin.default_actions(resource)
+  end
+
   defp unauthorized_access(conn) do
     conn
     |> put_flash(:error, "You are not authorized to access that page")
+    |> redirect(to: Kaffy.Utils.router().kaffy_home_path(conn, :index))
+  end
+
+  defp not_enabled(conn) do
+    conn
+    |> put_flash(:error, "This action has been disabled.")
     |> redirect(to: Kaffy.Utils.router().kaffy_home_path(conn, :index))
   end
 

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -9,12 +9,14 @@
             <div id="checkbox-selected-count" class="checkbox-selected-count float-right"></div>
           </h3>
         </div>
-        <div class="col-auto">
-          <%= link to: Kaffy.Utils.router().kaffy_resource_path(@conn, :new, @context, @resource), class: "btn btn-outline-primary" do %>
-            <i class="fas fa-plus"></i>
-            New <%= Kaffy.ResourceAdmin.singular_name(@my_resource) %>
-          <% end %>
-        </div>
+        <%=  if :new in Kaffy.ResourceAdmin.default_actions(@my_resource) do %>
+          <div class="col-auto">
+            <%= link to: Kaffy.Utils.router().kaffy_resource_path(@conn, :new, @context, @resource), class: "btn btn-outline-primary" do %>
+              <i class="fas fa-plus"></i>
+              New <%= Kaffy.ResourceAdmin.singular_name(@my_resource) %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
 


### PR DESCRIPTION
This commit allows removing the "new" button and form actions by
overriding a new `default_actions` function in the admin section.

Currently only the `new` action can be disabled, but it should be
possible to disable edit and delete with the same API.